### PR TITLE
HeyJamboJambo Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SOURCE_FILES
 	"src/Corth.cpp"
 )
 
-set(HEADER_FILES )
+set(HEADER_FILES "src/Errors.h")
 
 # Add source files project.
 add_executable (Corth ${HEADER_FILES} ${SOURCE_FILES})

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Corth is:
 Corth, like Porth (like Forth), is a stack based language. \
 This means that in order to do any operation, a value must be pushed onto the stack. \
 Think of this as a literal stack of objects. \
-Likely, the operation will take it's arguments from the top of the stack, or `pop` from the stack, and sometimes it will return a value or two back onto it.
+Likely, the operation will take it's arguments from the top of the stack, or `pop` from the stack, and sometimes it will return a value or two back onto it, which is called `pushing` on to the stack.
 
 ### A Simple Example <a name="how-to-a-simple-example"></a>
 Take a look at this example in Corth:
@@ -111,40 +111,41 @@ Let's break down how it works piece-by-piece:
 | Step | Code | Description                                                                                                                     |
 |------|------|---------------------------------------------------------------------------------------------------------------------------------|
 |    1 |`500 80 -` | Push two values on to the stack, subtract them, then push the result on to the stack.                                      |
-|    4 |`420` | Push `420` onto the stack                                                                                                       |
-|    5 |  `=` | Use the equality comparison operator; it pops two values off the stack, compares them, then pushes back a `1` if they are equal or a `0` if they aren't.|
-|    6 | `if` | Pop the condition just pushed onto the stack, jump to `else`/`endif` if it is false, otherwise, like in this case, fall-through to next instruction.|
-|    7 |`69 #`| Push a value onto the stack, then dump it to console output.                                                                    |
-|    8 |`else`| Label to jump to if `if` condition is false. Label to jump over to `endif` if `if` condition is true.                           |
-|    9 |`420 #`| This would push a value onto the stack, then dump it to console output, however it will be jumped over due to the `if` condition evaluating to true.|
-|   10 |`endif`| Label to jump to if `if` condition is false and no `else` label is present or if `if` condition is true and an `else` label is present.|
+|    2 |`420` | Push `420` onto the stack                                                                                                       |
+|    3 |  `=` | Use the equality comparison operator; it pops two values off the stack, compares them, then pushes back a `1` if they are equal or a `0` if they aren't.|
+|    4 | `if` | Pop the condition just pushed onto the stack, jump to `else`/`endif` if it is false, otherwise, like in this case, fall-through to next instruction.|
+|    5 |`69 #`| Push a value onto the stack, then dump it to console output.                                                                    |
+|    6 |`else`| Label to jump to if `if` condition is false. Label to jump over to `endif` if `if` condition is true.                           |
+|    7 |`420 #`| This would push a value onto the stack, then dump it to console output, however it will be jumped over due to the `if` condition evaluating to true.|
+|    8 |`endif`| Label to jump to if `if` condition is false and no `else` label is present or if `if` condition is true and an `else` label is present.|
 
 [To Top](#top)
 
 ---
 
 ### Loops <a name="how-to-loops"></a>
-Corth now fully supports loops! Check out the following simple example:
+Corth now fully supports loops! Check out the following example:
 ```
 1 
 while dup 30 <= do
-  dup #
-  1 +
+  dup dump    // Print loop counter without destroying it
+  10  dump_c  // Print a newline character
+  1 +         // Increment loop counter
 endwhile
 ```
 
-This program will print every whole number from `1` to `30`, each being on a new-line.
+This program will print every whole number from `1` to `30`, each being on a new line.
 
 Let's break down how it works:
 | Step | Code | Description                                                                                                                     |
-|------|------|---------------------------------------------------------------------------------------------------------------------------------|
-|    1 |  `1` | Push a one onto the stack to initialize the loop counter.                                                                       |
-|    2 |`while`| Generate an address to jump to upon reaching endwhile.                                                                         |
-|    3 |`dup 30 <=`| Push a boolean condition on the stack comparing whether the last item on the stack (duplicated) is less than or equal to `30`.|
-|    4 | `do` | Pop the condition just pushed onto the stack, jump just past `endwhile` (step 7) if it is zero, otherwise, like in this case, fall-through to next instruction.|
-|    5 |`dup #`| Duplicate the top-most value onto the stack, then dump the duplicate to console output. This prints the current loop counter, as that is what's on the stack.|
-|    6 |`1 +`| Add 1 to top-most value on the stack. This increments the loop counter.                                                          |
-|    7 |`endwhile`| Upon reaching, jump back to `while` (step 2) and continue execution from there.                                             |
+|------|-------------|---------------------------------------------------------------------------------------------------------------------------------|
+|    1 | `1`         | Push a one onto the stack to initialize the loop counter.                                                                       |
+|    2 | `while`     | Generate an address to jump to upon reaching endwhile.                                                                          |
+|    3 | `dup 30 <=` | Push a boolean condition on the stack comparing whether the last item on the stack (duplicated) is less than or equal to `30`.  |
+|    4 | `do`        | Pop the condition just pushed onto the stack, jump just past `endwhile` (step 7) if it is zero, otherwise, like in this case, fall-through to next instruction.|
+|    5 | `dup #`     | Duplicate the top-most value onto the stack, then dump the duplicate to console output. This prints the current loop counter, as that is what's on the stack.|
+|    6 | `1 +`       | Add 1 to top-most value on the stack. This increments the loop counter.                                                         |
+|    7 | `endwhile`  | Upon reaching, jump back to `while` (step 2) and continue execution from there.                                                 |
 
 It is known that this program will trigger a stack validator warning, telling us that the stack at the end of the program is not empty. \
 With programs as simple as these, it's okay to do, however best practices indicate that the stack should be empty by the end of the program.
@@ -594,7 +595,7 @@ Pops two values, `a` and `b`, off of the stack then pushes bits of `a` shifted r
 ```
 
 Equivalent
-- [Keyword: shl](#kw-shr)
+- [Keyword: shr](#kw-shr)
 
 Related
 - No related
@@ -625,7 +626,7 @@ Pops two values, `a` and `b`, off of the stack, then pushes the [bitwise-and](ht
 ```
 
 Equivalent
-- [Keyword: shl](#kw-and)
+- [Keyword: and](#kw-and)
 
 Related
 - No related
@@ -656,7 +657,7 @@ Pops two values, `a` and `b`, off of the stack, then pushes the [bitwise-or](htt
 ```
 
 Equivalent
-- [Keyword: shl](#kw-or)
+- [Keyword: or](#kw-or)
 
 Related
 - No related
@@ -1259,7 +1260,7 @@ Equivalent:
 - Operator: [>>](#op-bit-shr)
 
 Related:
-- Keyword: [shr](#kw-shl)
+- Keyword: [shl](#kw-shl)
 
 Example:
 ```
@@ -1280,6 +1281,8 @@ Standard Output:
 ```
 ```
 
+[To Keywords](#corth-keywords)
+
 ---
 
 #### 'and' - Bitwise Operator <a name="kw-and"></a>
@@ -1292,7 +1295,7 @@ An AND operation entails the output only containing a `1` if both inputs do.
 ```
 
 Equivalent:
-- No equivalent
+- Operator: [&&](#op-bit-and)
 
 Related:
 - Keyword: [or](#kw-or)
@@ -1314,6 +1317,8 @@ Standard Output:
 ```
 ```
 
+[To Keywords](#corth-keywords)
+
 ---
 
 #### 'or' - Bitwise Operator <a name="kw-or"></a>
@@ -1326,10 +1331,10 @@ An OR operation entails the output containing a `1` if one or both of the inputs
 ```
 
 Equivalent:
-- No equivalent
+- Operator: [||](#op-bit-or)
 
 Related:
-- Keyword: [or](#kw-or)
+- Keyword: [and](#kw-and)
 
 Example:
 ```

--- a/examples/fizzbuzz.corth
+++ b/examples/fizzbuzz.corth
@@ -9,8 +9,8 @@ while dup 100 < do
 	  dup 5 mod 0 = if
 	    "Buzz\n" dump_s
 	  else
-	    // Print loop counter
-	    dup dump
+	    dup dump   // Print loop counter
+		10 dump_c  // Print new-line
 	  endif
     endif
   endif

--- a/examples/fizzbuzz.corth
+++ b/examples/fizzbuzz.corth
@@ -4,10 +4,10 @@ while dup 100 < do
     "FizzBuzz\n" dump_s
   else
     dup 3 mod 0 = if
-	  "Fizz\n" dump_s
+	  "Fizz\r\n" dump_s
 	else
 	  dup 5 mod 0 = if
-	    "Buzz\n" dump_s
+	    "\tBuzz\n" dump_s
 	  else
 	    dup dump   // Print loop counter
 		10 dump_c  // Print new-line

--- a/examples/fizzbuzz.corth
+++ b/examples/fizzbuzz.corth
@@ -4,10 +4,10 @@ while dup 100 < do
     "FizzBuzz\n" dump_s
   else
     dup 3 mod 0 = if
-	  "Fizz\r\n" dump_s
+	  "Fizz\n" dump_s
 	else
 	  dup 5 mod 0 = if
-	    "\tBuzz\n" dump_s
+	    "Buzz\n" dump_s
 	  else
 	    dup dump   // Print loop counter
 		10 dump_c  // Print new-line

--- a/examples/helloworld.corth
+++ b/examples/helloworld.corth
@@ -1,2 +1,2 @@
 // Hello world in Corth
-"Hello, World!" dump_s
+"Hello, World!\n" dump_s

--- a/src/Corth.cpp
+++ b/src/Corth.cpp
@@ -633,15 +633,16 @@ namespace Corth {
                 }
                 instr_ptr++;
             }
-            // WRITE ASM FOOTER (GRACEFUL PROGRAM EXIT, CONSTANTS, MEMORY ALLOCATION)
+            // WRITE ASM FOOTER (GRACEFUL PROGRAM EXIT, CONSTANTS)
             asm_file << "    mov rdi, 0\n"
                      << "    call exit\n"
                      << '\n'
                      << "    SECTION .data\n"
-                     << "    fmt db '%u', 10, 0\n"
+                     << "    fmt db '%u', 0\n"
                      << "    fmt_char db '%c', 0\n"
                      << "    fmt_str db '%s', 0\n";
 
+			// WRITE USER DEFINED STRING CONSTANTS
             size_t index = 0;
             for (auto& string : string_literals) {
                 std::vector<std::string> hex_chars = string_to_hex(string);
@@ -653,7 +654,8 @@ namespace Corth {
                 asm_file << "0\n";
                 index++;
             }
-                
+
+			// ALLOCATE MEMORY
             asm_file << '\n'
                      << "    SECTION .bss\n"
                      << "    mem resb " << MEM_CAPACITY << '\n';
@@ -1021,21 +1023,25 @@ namespace Corth {
                 }
                 instr_ptr++;
             }
-            // WRITE ASM FOOTER (GRACEFUL PROGRAM EXIT, CONSTANTS, MEMORY ALLOCATION)
+			
+            // WRITE ASM FOOTER (GRACEFUL PROGRAM EXIT, CONSTANTS)
             asm_file << "    mov $0, %rdi\n"
                      << "    call exit\n"
                      << '\n'
                      << "    .data\n"
-                     << "    fmt: .string \"%u\\n\"\n"
+                     << "    fmt: .string \"%u\"\n"
                      << "    fmt_char: .string \"%c\"\n"
                      << "    fmt_str: .string \"%s\"\n";
 
+			// WRITE USER DEFINED STRING CONSTANTS
             size_t index = 0;
             if (string_literals.size() > 0) { asm_file << "\n    # USER DEFINED STRINGS\n"; }
             for (auto& string : string_literals) {
                 asm_file << "str_" << index << ": .string \"" << string << "\"\n";
                 index++;
             }
+
+			// ALLOCATE MEMORY
             asm_file << '\n'
                      << "    .bss\n"
                      << "    .comm mem, " << MEM_CAPACITY << '\n';
@@ -1075,7 +1081,7 @@ namespace Corth {
             asm_file << "    ;; -- TODO: graceful exit --\n"
                      << "\n\n"
                      << "    SECTION .data\n"
-                     << "    fmt db '%u', 10, 0\n"
+                     << "    fmt db '%u', 0\n"
                      << "    fmt_char db '%c', 0\n"
                      << "    fmt_str db '%s', 0\n";
         }
@@ -1459,7 +1465,7 @@ namespace Corth {
 
             // DECLARE CORTH CONSTANTS
             asm_file << "    SECTION .data\n"
-                     << "    fmt db '%u', 10, 0\n"
+                     << "    fmt db '%u', 0\n"
                      << "    fmt_char db '%c', 0\n"
                      << "    fmt_str db '%s', 0\n";
 
@@ -1850,27 +1856,31 @@ namespace Corth {
                 }
                 instr_ptr++;
             }
-            // WRITE ASM FOOTER (GRACEFUL PROGRAM EXIT, CONSTANTS, MEMORY ALLOCATION)
+            // WRITE ASM FOOTER (GRACEFUL PROGRAM EXIT, CONSTANTS)
             asm_file << "    mov $0, %rcx\n"
                      << "    call exit\n"
                      << '\n'
                      << "    .data\n"
-                     << "    fmt: .string \"%u\\n\"\n"
+                     << "    fmt: .string \"%u\"\n"
                      << "    fmt_char: .string \"%c\"\n"
                      << "    fmt_str: .string \"%s\"\n";
 
+			// WRITE USER DEFINED STRINGS
             size_t index = 0;
             if (string_literals.size() > 0) { asm_file << "\n    # USER DEFINED STRINGS\n"; }
             for (auto& string : string_literals) {
                 asm_file << "str_" << index << ": .string \"" << string << "\"\n";
                 index++;
             }
+
+			// ALLOCATE MEMORY
             asm_file << '\n'
                      << "    .bss\n"
                      << "    .comm mem, " << MEM_CAPACITY << '\n';
-            
+
+			// Close open filestream.
             asm_file.close();
-                
+			
             Log("WIN64 GAS assembly generated at " + asm_file_path);
         }
         else {


### PR DESCRIPTION
## Thank you u/HeyJamboJambo in r/ProgrammingLanguages

Dump no longer prints a newline by default.

Multiple patch-ups to the README (incorrect link text, confusing step numbering, etc).

Newlines, tabs, and linefeeds are now supported within string constants in Corth. \
They sort of were before, but only because GAS handles it by default. \
Assembly generated for NASM now has the same behaviour (due to Corth in NASM syntax no longer handling strings as literals, but as vectors of hex characters that are generated and validated (see string_to_hex method in Corth.cpp).

Also corrected a small error in the CMakeLists.txt concering the Errors header, ironically.